### PR TITLE
`querystring.parse` is legacy, upgraded to newer recommendations

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Converts request body to string.
 
 ### `urlencoded(req, res, cb)`
 
-Parses request body using `querystring.parse`.
+Parses request body using `new URLSearchParams`.
 
 ### `json(req, res, cb)`
 

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -14,6 +14,6 @@ export default [
   {
     input: 'src/index.ts',
     ...common,
-    external: ['querystring', 'http'],
+    external: ['http'],
   },
 ]

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,4 @@
 import { ServerResponse as Response, IncomingMessage, STATUS_CODES } from 'http'
-import * as qs from 'querystring'
 import { EventEmitter } from 'events'
 
 type NextFunction = (err?: any) => void
@@ -54,7 +53,10 @@ const text = () => async (req: ReqWithBody, _res: Response, next: NextFunction) 
 
 const urlencoded = () => async (req: ReqWithBody, res: Response, next: NextFunction) => {
   if (hasBody(req.method)) {
-    req.body = await p((x) => qs.parse(x.toString()))(req, res, next)
+    req.body = await p((x) => {
+      const urlSearchParam = new URLSearchParams(x.toString());
+      return Object.fromEntries(urlSearchParam.entries())
+    })(req, res, next)
     next()
   } else next()
 }


### PR DESCRIPTION
NodeJS docs state "The querystring API is considered Legacy. While it is still maintained, new code should use the <URLSearchParams> API instead" https://nodejs.org/api/querystring.html

Upgraded this to the recommended solution