### PR TITLE
Fix raw and text parser.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -42,12 +42,18 @@ const json = () => async (req: ReqWithBody, res: Response, next: NextFunction) =
 }
 
 const raw = () => async (req: ReqWithBody, _res: Response, next: NextFunction) => {
-  if (hasBody(req.method)) req.body = await p((x) => x)(req, _res, next)
+  if (hasBody(req.method)) {
+    req.body = await p((x) => x)(req, _res, next)
+    next()
+  }
   else next()
 }
 
 const text = () => async (req: ReqWithBody, _res: Response, next: NextFunction) => {
-  if (hasBody(req.method)) req.body = await p((x) => x.toString())(req, _res, next)
+  if (hasBody(req.method)) {
+    req.body = await p((x) => x.toString())(req, _res, next)
+    next()
+  }
   else next()
 }
 


### PR DESCRIPTION
`next()` is missing in raw and text parsers when `hasBody()` is true, resulting requests stuck in these parsers when using it with tinyhttp.

This pull request added missing function calls so these parsers can works properly. 