### PR TITLE
fix: allow empty json body

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -36,7 +36,7 @@ const custom =
 
 const json = () => async (req: ReqWithBody, res: Response, next: NextFunction) => {
   if (hasBody(req.method)) {
-    req.body = await p((x) => JSON.parse(x.toString()))(req, res, next)
+    req.body = await p((x) => x ? JSON.parse(x.toString()) : {})(req, res, next)
     next()
   } else next()
 }

--- a/test.ts
+++ b/test.ts
@@ -31,8 +31,18 @@ test('should ignore JSON empty body', async () => {
     res.end(JSON.stringify({ok: true}));
   })
 
+  // Empty string body
   await makeFetch(server)('/', {
     body: '',
+    method: 'POST',
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+    },
+  }).expect(200, { ok: true })
+
+  // Unset body
+  await makeFetch(server)('/', {
     method: 'POST',
     headers: {
       Accept: 'application/json',

--- a/test.ts
+++ b/test.ts
@@ -22,6 +22,25 @@ test('should parse JSON body', async () => {
   }).expect(200, { hello: 'world' })
 })
 
+test('should ignore JSON empty body', async () => {
+  const server = createServer(async (req: ReqWithBody, res) => {
+    await json()(req, res, (err) => void err && console.log(err))
+
+    res.setHeader('Content-Type', 'application/json')
+
+    res.end(JSON.stringify({ok: true}));
+  })
+
+  await makeFetch(server)('/', {
+    body: '',
+    method: 'POST',
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+    },
+  }).expect(200, { ok: true })
+})
+
 test('should parse json body with no content-type headers', async () => {
   const server = createServer(async (req: ReqWithBody, res) => {
     await json()(req, res, (err) => void err && console.log(err))


### PR DESCRIPTION
The json middleware crashes when it receives an empty string from req.chunk.
This causes JSON.parse() to throw an exception since it does not accept empty strings.