### PR TITLE
fix: lower engines to 18.13 || 19.20

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,8 +27,8 @@ jobs:
         run: corepack enable pnpm
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
-          cache: 'pnpm'
+          node-version: 18.13
+          cache: "pnpm"
       - run: pnpm install
       - run: pnpm test:coverage
       - run: pnpm test:report

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "body-parsing"
   ],
   "engines": {
-    "node": ">=20"
+    "node": ">=18.13 || >=19.20 || >=20"
   },
   "exports": "./dist/index.js",
   "devDependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { Buffer } from 'node:buffer'
+import { Buffer, File } from 'node:buffer'
 import type { IncomingMessage, ServerResponse as Response } from 'node:http'
 
 type NextFunction = (err?: any) => void


### PR DESCRIPTION
the node 20.x is a bit too high right now, lowered to 18.x where File is available, but experimental (though still works fine)