### PR TITLE
Fix JSON benchmarks

### DIFF
--- a/bench/index.md
+++ b/bench/index.md
@@ -17,7 +17,7 @@ conditions.
 ### Benchmark command:
 
 ```sh
-autocannon -b '{"a":1}' -H "Content-Type=application/json" localhost:3002 # or 3003
+autocannon -m POST -b '{"a":1}' -H "Content-Type=application/json" localhost:3002 # or 3003
 ```
 
 ### Results

--- a/bench/package.json
+++ b/bench/package.json
@@ -5,7 +5,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "bench": "autocannon -b '{\"a\":1}' -H \"Content-Type=application/json\"",
+    "bench": "autocannon -m POST -b '{\"a\":1}' -H \"Content-Type=application/json\"",
     "bench:multipart": "autocannon -m POST --form '{ \"file\": { \"type\": \"file\", \"path\": \"./file.txt\" } }'"
   },
   "keywords": [],


### PR DESCRIPTION
With the commands currently provided autocannon sends GET requests for the JSON benchmarks which doesn't properly benchmark the parsers considering milliparsec doesn't parse the body of GET requests whilst body-parser does. This changes autocannon to send POST requests.